### PR TITLE
helm: Helm chart tunes

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            pathType: ImplementationSpecific
+            pathType: Prefix
             backend:
               service:
                 name: {{ include "onetimesecret-chart.fullname" $ }}

--- a/templates/onetimesecret-deployment.yaml
+++ b/templates/onetimesecret-deployment.yaml
@@ -25,7 +25,9 @@ spec:
         - name: COLONEL
           value: "{{ .Values.onetimesecret.env.COLONEL }}"
         - name: HOST
-          value: "{{ include "onetimesecret-chart.onetimesecret.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ include "onetimesecret-service.port" .}}"
+          {{- with (first .Values.ingress.hosts) }}
+          value: "{{ .host }}"
+          {{- end  }}
         - name: SSL
           value: "{{ .Values.onetimesecret.env.SSL }}"
         - name: SMTP_HOST

--- a/values.yaml
+++ b/values.yaml
@@ -17,7 +17,7 @@ onetimesecret:
     type: ClusterIP
   env:
     COLONEL: "admin@example.com"
-    SSL: "false"  # Ensure this is a string
+    SSL: "true"  # Ensure this is a string
     SMTP_HOST: "smtp.example.com" # Update your smtp configuration details
     SMTP_PORT: "587"
     SMTP_USERNAME: "username"
@@ -27,6 +27,7 @@ onetimesecret:
 
 
 ingress:
+  # ingressClassName: ""
   enabled: true
   annotations: {}
   hosts:


### PR DESCRIPTION
### **User description**
The following changes were tested on AWS EKS.

1. Add missing `ingressClassName` key to the `values.yaml` under ingress block
2. `pathType: Prefix` will expose all existing endpoints but `pathType: ImplementationSpecific` exposes `/` path as `Exact` match. See docs - https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
3. Rework fulfilment of the `HOST` environment variable to fetch the value from the ingress resource values. Previously, it was set to `localhost` even if the application was exposed with ingress resource


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Changed `pathType` from `ImplementationSpecific` to `Prefix` for ingress paths.
- Modified `HOST` environment variable to fetch value from ingress resource.
- Added `ingressClassName` key under ingress block in `values.yaml`.
- Set `SSL` to `true` by default in `values.yaml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ingress.yaml</strong><dd><code>Update ingress pathType to Prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/ingress.yaml

<li>Changed <code>pathType</code> from <code>ImplementationSpecific</code> to <code>Prefix</code> for ingress <br>paths.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/helm-charts/pull/4/files#diff-612d87a9a43b4e6ad348a1ad96e963734289a06ecd01902e82c3b03201fb9874">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add ingressClassName key and set SSL to true by default</code>&nbsp; &nbsp; </dd></summary>
<hr>

values.yaml

<li>Added <code>ingressClassName</code> key under ingress block.<br> <li> Set <code>SSL</code> to <code>true</code> by default.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/helm-charts/pull/4/files#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>onetimesecret-deployment.yaml</strong><dd><code>Update HOST environment variable to match ingress hostname</code></dd></summary>
<hr>

templates/onetimesecret-deployment.yaml

<li>Modified <code>HOST</code> environment variable to fetch value from ingress <br>resource.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/helm-charts/pull/4/files#diff-48439a01f6037dd49ca3cca641926ec2ae59c27c13583db218b03be2701194a3">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

